### PR TITLE
Pi 4 Modifications and Headerless PCM stream flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,15 +3,19 @@ STD_CFLAGS = -Wall -Wno-multichar -std=gnu99 -c -g -O1
 
 # Enable ARM-specific options only on ARM, and compilation of the app only on ARM
 UNAME := $(shell uname -m)
+PCPUI := $(shell cat /proc/cpuinfo | grep Revision | cut -c16-)
 
 # Determine the hardware platform. Below, pi1 stands for the RaspberryPi 1 (the original one),
 # and pi2 stands for both the RaspberryPi 2 and 3.
 ifeq ($(UNAME), armv6l)
 	CFLAGS = $(STD_CFLAGS) -march=armv6 -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=1
 	TARGET = pi1
+else ifeq ($(PCPUI), 11)
+		CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=4
+		TARGET = pi4
 else ifeq ($(UNAME), armv7l)
-	CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=2
-	TARGET = pi2
+		CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=2
+		TARGET = pi2
 else
 	CFLAGS = $(STD_CFLAGS)
 	TARGET = other

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,11 +11,11 @@ ifeq ($(UNAME), armv6l)
 	CFLAGS = $(STD_CFLAGS) -march=armv6 -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=1
 	TARGET = pi1
 else ifeq ($(PCPUI), 11)
-		CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=4
-		TARGET = pi4
+	CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=4
+	TARGET = pi4
 else ifeq ($(UNAME), armv7l)
-		CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=2
-		TARGET = pi2
+	CFLAGS = $(STD_CFLAGS) -march=armv7-a -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp -ffast-math -DRASPI=2
+	TARGET = pi2
 else
 	CFLAGS = $(STD_CFLAGS)
 	TARGET = other

--- a/src/fm_mpx.c
+++ b/src/fm_mpx.c
@@ -57,12 +57,20 @@ double *alloc_empty_buffer(size_t length) {
 
 
 
-int fm_mpx_open(char *filename, size_t len, int cutoff_freq, int preemphasis_corner_freq) {
+int fm_mpx_open(char *filename, size_t len, int cutoff_freq, int preemphasis_corner_freq, int srate, int nochan) {
 	length = len;
 
 	if(filename != NULL) {
 		// Open the input file
 		SF_INFO sfinfo;
+
+                if(filename[0] == '-' && srate > 0 && nochan > 0) {
+                        printf("Using stdin for raw audio input at %d Hz.\n",srate);
+        		sfinfo.samplerate = srate;
+        		sfinfo.format = SF_FORMAT_RAW | SF_FORMAT_PCM_16 | SF_ENDIAN_LITTLE;
+        		sfinfo.channels = nochan;
+        		sfinfo.frames = 0;
+                } 
 
 		// stdin or file on the filesystem?
 		if(filename[0] == '-') {

--- a/src/fm_mpx.h
+++ b/src/fm_mpx.h
@@ -5,6 +5,6 @@
     See https://github.com/Miegl/PiFmAdv
 */
 
-extern int fm_mpx_open(char *filename, size_t len, int cutoff_freq, int preemphasis_corner_freq);
+extern int fm_mpx_open(char *filename, size_t len, int cutoff_freq, int preemphasis_corner_freq, int srate, int nochan);
 extern int fm_mpx_get_samples(double *mpx_buffer, double *rds_buffer, float mpx, int rds, int wait);
 extern int fm_mpx_close();

--- a/src/pi_fm_adv.c
+++ b/src/pi_fm_adv.c
@@ -43,7 +43,7 @@
 #define MEM_FLAG                        0x04
 #define CLOCK_BASE			19.2e6
 #define DMA_CHANNEL			14
-#elif (RASPI) == 4                      // Raspberry Pi 2 & 3
+#elif (RASPI) == 4                      // Raspberry Pi 4
 #define PERIPH_VIRT_BASE                0xfe000000
 #define PERIPH_PHYS_BASE                0x7e000000
 #define DRAM_PHYS_BASE                  0xc0000000

--- a/src/pi_fm_adv.c
+++ b/src/pi_fm_adv.c
@@ -34,11 +34,22 @@
 #define PERIPH_PHYS_BASE                0x7e000000
 #define DRAM_PHYS_BASE                  0x40000000
 #define MEM_FLAG                        0x0c
+#define XTAL_CLOCK			19.2e6
+#define DMA_CHANNEL                     14
 #elif (RASPI) == 2                      // Raspberry Pi 2 & 3
 #define PERIPH_VIRT_BASE                0x3f000000
 #define PERIPH_PHYS_BASE                0x7e000000
 #define DRAM_PHYS_BASE                  0xc0000000
 #define MEM_FLAG                        0x04
+#define XTAL_CLOCK			19.2e6
+#define DMA_CHANNEL                     14
+#elif (RASPI) == 4                      // Raspberry Pi 4
+#define PERIPH_VIRT_BASE                0xfe000000
+#define PERIPH_PHYS_BASE                0x7e000000
+#define DRAM_PHYS_BASE                  0xc0000000
+#define MEM_FLAG                        0x04
+#define XTAL_CLOCK			54.0e6
+#define DMA_CHANNEL                     6
 #else
 #error Unknown Raspberry Pi version (variable RASPI)
 #endif
@@ -184,7 +195,6 @@
 #define GPIO_PAD_46_52                  (0x34/4)
 
 // DMA
-#define DMA_CHANNEL                     14
 #define DMA_CHANNEL_MAX                 14
 #define DMA_CHANNEL_SIZE                0x100
 
@@ -207,16 +217,6 @@
 #define DMA_CS                          (0x00/4)
 #define DMA_CONBLK_AD                   (0x04/4)
 #define DMA_DEBUG                       (0x20/4)
-
-#define DMA_CS_RESET			(1<<31)
-#define DMA_CS_ABORT			(1<<30)
-#define DMA_CS_DISDEBUG			(1<<29)
-#define DMA_CS_WAIT_FOR_OUTSTANDING_WRITES (1<<28)
-#define DMA_CS_INT			(1<<2)
-#define DMA_CS_END			(1<<1)
-#define DMA_CS_ACTIVE			(1<<0)
-#define DMA_CS_PRIORITY(x)		((x)&0xf << 16)
-#define DMA_CS_PANIC_PRIORITY(x)	((x)&0xf << 20)
 
 #define DREQ_PCM_TX                     2
 #define DREQ_PCM_RX                     3
@@ -292,8 +292,8 @@ static void terminate(int num)
 	udelay(10);
 	gpio_reg[3] = (gpio_reg[3] & ~(7 << 6)) | (1 << 6); //GPIO32
 	udelay(10);
-	//gpio_reg[3] = (gpio_reg[3] & ~(7 << 12)) | (1 << 12); //GPIO34 - Doesn't work on Pi 3, 3B+, Zero W
-	//udelay(10);
+	gpio_reg[3] = (gpio_reg[3] & ~(7 << 12)) | (1 << 12); //GPIO34
+	udelay(10);
 
         // Disable the clock generator.
         clk_reg[GPCLK_CNTL] = 0x5A;
@@ -366,7 +366,7 @@ static void *map_peripheral(uint32_t base, uint32_t len)
 
 
 
-int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t pi, char *ps, char *rt, int *af_array, float ppm, float deviation, float mpx, int cutoff, int preemphasis_cutoff, char *control_pipe, int pty, int tp, int power, int gpio, int wait) {
+int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t pi, char *ps, char *rt, int *af_array, float ppm, float deviation, float mpx, int cutoff, int preemphasis_cutoff, char *control_pipe, int pty, int tp, int power, int gpio, int wait, int srate, int nochan) {
 	// Catch only important signals
 	for (int i = 0; i < 25; i++) {
 		struct sigaction sa;
@@ -428,7 +428,7 @@ int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t p
 
 
 	// Adjust PLLA frequency
-	freq_ctl = (unsigned int)(((carrier_freq*divider)/19.2e6*((double)(1<<20))));
+	freq_ctl = (unsigned int)(((carrier_freq*divider)/XTAL_CLOCK*((double)(1<<20))));
 	clk_reg[PLLA_CTRL] = (0x5a<<24) | (0x21<<12) | (freq_ctl>>20); // Integer part
 	freq_ctl&=0xFFFFF;
 	clk_reg[PLLA_FRAC] = (0x5a<<24) | (freq_ctl&0xFFFFC); // Fractional part
@@ -537,7 +537,7 @@ int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t p
 	int data_index = 0;
 
 	// Initialize the baseband generator
-	if(fm_mpx_open(audio_file, DATA_SIZE, cutoff, preemphasis_cutoff) < 0) return 1;
+	if(fm_mpx_open(audio_file, DATA_SIZE, cutoff, preemphasis_cutoff, srate, nochan) < 0) return 1;
 
 	// Initialize the RDS modulator
 	set_rds_pi(pi);
@@ -580,7 +580,7 @@ int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t p
 
 	printf("Starting to transmit on %3.1f MHz.\n", carrier_freq/1e6);
 
-	double deviation_scale_factor =  0.1 * (divider*(deviation*1000)/(19.2e6/((double)(1<<20))));
+	double deviation_scale_factor =  0.1 * (divider*(deviation*1000)/(XTAL_CLOCK/((double)(1<<20))));
 
 	for (;;) {
 
@@ -617,7 +617,7 @@ int tx(uint32_t carrier_freq, int divider, char *audio_file, int rds, uint16_t p
 		}
 		last_cb = (uint32_t)mbox.virt_addr + last_sample * sizeof(dma_cb_t) * 2;
 
-		usleep(5000);
+		usleep(1000);
 	}
 
 	return 0;
@@ -646,6 +646,8 @@ int main(int argc, char **argv) {
 	int gpio = 4;
 	float mpx = 40;
 	int wait = 1;
+        int srate = 0;
+        int nochan = 0;
 
 	const char    	*short_opt = "a:f:d:p:c:P:D:m:w:W:C:h";
 	struct option   long_opt[] =
@@ -670,6 +672,9 @@ int main(int argc, char **argv) {
 		{"tp",		required_argument, NULL, 'tp'},
 		{"af", 		required_argument, NULL, 'af'},
 		{"ctl", 	required_argument, NULL, 'C'},
+
+		{"srate", 	required_argument, NULL, 'S'},
+		{"nochan", 	required_argument, NULL, 'N'},
 
 		{"help",	no_argument, NULL, 'h'},
 		{ 0, 		0, 		   0,    0 }
@@ -731,14 +736,22 @@ int main(int argc, char **argv) {
 				break;
 
 			case 'g': //gpio
-                                gpio = atoi(optarg);
-                                if(gpio != 4 && gpio != 20 && gpio != 32) // && gpio != 34)
-                                        fatal("Available GPIO pins: 4,20,32\n");
+                                gpio = atoi(optarg); 
+                                if(gpio != 4 && gpio != 20 && gpio != 32 && gpio != 34)
+                                        fatal("Available GPIO pins: 4,20,32,34\n");
                                 break;
 
 			case 'W': //wait
                                 wait = atoi(optarg);
                                 break;
+
+			case 'S': //sample rate
+				srate = atoi(optarg);
+				break;
+
+			case 'N': //number of channels
+				nochan = atoi(optarg);
+				break;
 
 			case 'rds': //rds
 				rds = atoi(optarg);
@@ -798,7 +811,7 @@ int main(int argc, char **argv) {
 
 	alternative_freq[0] = af_size;
 
-	double xtal_freq_recip=1.0/19.2e6;
+	double xtal_freq_recip=1.0/XTAL_CLOCK;
 	int divider, best_divider = 0;
 	int min_int_multiplier, max_int_multiplier;
 	int int_multiplier;
@@ -843,7 +856,7 @@ int main(int argc, char **argv) {
 
 	printf("Carrier: %3.2f Mhz, VCO: %4.1f MHz, Multiplier: %f, Divider: %d\n", carrier_freq/1e6, (double)carrier_freq * best_divider / 1e6, carrier_freq * best_divider * xtal_freq_recip, best_divider);
 	
-	int errcode = tx(carrier_freq, best_divider, audio_file, rds, pi, ps, rt, alternative_freq, ppm, deviation, mpx, cutoff, preemphasis_cutoff, control_pipe, pty, tp, power, gpio, wait);
+	int errcode = tx(carrier_freq, best_divider, audio_file, rds, pi, ps, rt, alternative_freq, ppm, deviation, mpx, cutoff, preemphasis_cutoff, control_pipe, pty, tp, power, gpio, wait, srate, nochan);
 
 	terminate(errcode);
 }


### PR DESCRIPTION
Notes: 
Makefile : /proc/cpuinfo was the only way I could determine Pi 4 hardware, all three memory variants Revision end in "11". 
int srate ( sample rate ) and int nochan ( number of channels ) is necessary for PCM streams without a detectable header to determine these values. ( mpg123 --stdout <> |  as an example )
CLOCK_BASE and DMA_CHANNEL are now hardware dependent. For an analysis of these new Pi 4 values , please see : https://www.raspberrypi.org/forums/viewtopic.php?f=72&t=244479&start=25
