### PR TITLE
Add MPX composite input mode (--mpxin)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,8 +34,8 @@ endif
 
 ifneq ($(TARGET), other)
 
-app: rds.o waveforms.o pi_fm_adv.o fm_mpx.o control_pipe.o mailbox.o
-	$(CC) -o pi_fm_adv rds.o waveforms.o mailbox.o pi_fm_adv.o fm_mpx.o control_pipe.o -lm -lsndfile -lsoxr
+app: rds.o waveforms.o pi_fm_adv.o fm_mpx.o mpx_input.o control_pipe.o mailbox.o
+	$(CC) -o pi_fm_adv rds.o waveforms.o mailbox.o pi_fm_adv.o fm_mpx.o mpx_input.o control_pipe.o -lm -lsndfile -lsoxr
 
 endif
 
@@ -63,6 +63,9 @@ rds_wav.o: rds_wav.c
 
 fm_mpx.o: fm_mpx.c fm_mpx.h
 	$(CC) $(CFLAGS) fm_mpx.c
+
+mpx_input.o: mpx_input.c mpx_input.h
+	$(CC) $(CFLAGS) mpx_input.c
 
 clean:
 	rm -f *.o

--- a/src/mpx_input.c
+++ b/src/mpx_input.c
@@ -1,0 +1,109 @@
+/*
+    PiFmAdv - Advanced FM transmitter for the Raspberry Pi
+    Copyright (C) 2017 Miegl
+
+    See https://github.com/Miegl/PiFmAdv
+*/
+
+#include <sndfile.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "mpx_input.h"
+
+#define MPX_INPUT_BUF_LEN 4096
+
+int mpx_input_samplerate;
+
+static SNDFILE *inf;
+static int channels;
+static float *read_buffer;
+static int wait_mode = 1;
+
+int mpx_input_open(char *filename, int srate, int nochan) {
+    SF_INFO sfinfo;
+
+    memset(&sfinfo, 0, sizeof(sfinfo));
+
+    if (filename[0] == '-') {
+        if (srate <= 0 || nochan <= 0) {
+            fprintf(stderr, "Error: --srate and --nochan are required for MPX input from stdin.\n");
+            return -1;
+        }
+        sfinfo.samplerate = srate;
+        sfinfo.format = SF_FORMAT_RAW | SF_FORMAT_PCM_16 | SF_ENDIAN_LITTLE;
+        sfinfo.channels = nochan;
+        sfinfo.frames = 0;
+
+        if (!(inf = sf_open_fd(fileno(stdin), SFM_READ, &sfinfo, 0))) {
+            fprintf(stderr, "Error: could not open stdin for MPX input.\n");
+            return -1;
+        }
+        printf("Using stdin for MPX input at %d Hz.\n", srate);
+        wait_mode = 1;
+    } else {
+        if (!(inf = sf_open(filename, SFM_READ, &sfinfo))) {
+            fprintf(stderr, "Error: could not open MPX input file %s.\n", filename);
+            return -1;
+        }
+        printf("Using MPX input file: %s\n", filename);
+        wait_mode = 0;
+    }
+
+    mpx_input_samplerate = sfinfo.samplerate;
+    channels = sfinfo.channels;
+
+    printf("MPX input: %d Hz, %d channel(s).\n", mpx_input_samplerate, channels);
+
+    read_buffer = malloc(MPX_INPUT_BUF_LEN * channels * sizeof(float));
+    if (read_buffer == NULL) {
+        fprintf(stderr, "Error: could not allocate MPX input buffer.\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int mpx_input_get_samples(double *buffer, int len, float gain) {
+    if (inf == NULL) return -1;
+
+    int request = len < MPX_INPUT_BUF_LEN ? len : MPX_INPUT_BUF_LEN;
+    sf_count_t read_count = sf_readf_float(inf, read_buffer, request);
+
+    if (read_count < 0) {
+        fprintf(stderr, "Error reading MPX input.\n");
+        return -1;
+    }
+
+    if (read_count == 0) {
+        if (sf_seek(inf, 0, SEEK_SET) < 0) {
+            if (wait_mode) {
+                return 0;
+            } else {
+                fprintf(stderr, "Could not rewind MPX input file, terminating.\n");
+                return -1;
+            }
+        }
+        read_count = sf_readf_float(inf, read_buffer, request);
+        if (read_count <= 0) return -1;
+    }
+
+    for (int i = 0; i < read_count; i++) {
+        buffer[i] = (double)read_buffer[i * channels] * gain;
+    }
+
+    return (int)read_count;
+}
+
+int mpx_input_close() {
+    if (read_buffer != NULL) {
+        free(read_buffer);
+        read_buffer = NULL;
+    }
+    if (inf != NULL) {
+        sf_close(inf);
+        inf = NULL;
+    }
+    return 0;
+}

--- a/src/mpx_input.h
+++ b/src/mpx_input.h
@@ -1,0 +1,16 @@
+/*
+    PiFmAdv - Advanced FM transmitter for the Raspberry Pi
+    Copyright (C) 2017 Miegl
+
+    See https://github.com/Miegl/PiFmAdv
+*/
+
+#ifndef MPX_INPUT_H
+#define MPX_INPUT_H
+
+extern int mpx_input_open(char *filename, int srate, int nochan);
+extern int mpx_input_get_samples(double *buffer, int len, float gain);
+extern int mpx_input_close();
+extern int mpx_input_samplerate;
+
+#endif /* MPX_INPUT_H */

--- a/src/pi_fm_adv.c
+++ b/src/pi_fm_adv.c
@@ -24,6 +24,7 @@
 
 #include "rds.h"
 #include "fm_mpx.h"
+#include "mpx_input.h"
 #include "control_pipe.h"
 #include "mailbox.h"
 
@@ -295,6 +296,8 @@ static void udelay(int us)
     nanosleep(&ts, NULL);
 }
 
+static int mpx_mode = 0;
+
 static void terminate(int num)
 {
     // Stop outputting and generating the clock.
@@ -310,7 +313,10 @@ static void terminate(int num)
         udelay(10);
     }
 
-    fm_mpx_close();
+    if (mpx_mode)
+        mpx_input_close();
+    else
+        fm_mpx_close();
     close_control_pipe();
 
     if (mbox.virt_addr != NULL) {
@@ -372,7 +378,7 @@ static volatile void *map_peripheral(uint32_t base, uint32_t len)
 
 
 
-int tx(uint32_t carrier_freq, int divider, int prediv, char *audio_file, int rds, uint16_t pi, char *ps, char *rt, int *af_array, float ppm, float deviation, float mpx, int cutoff, int preemphasis_cutoff, char *control_pipe, int pty, int tp, int power, int pll, int gpclk, int *gpio, int wait, int srate, int nochan) {
+int tx(uint32_t carrier_freq, int divider, int prediv, char *audio_file, char *mpx_input_file, int rds, uint16_t pi, char *ps, char *rt, int *af_array, float ppm, float deviation, float mpx, int cutoff, int preemphasis_cutoff, char *control_pipe, int pty, int tp, int power, int pll, int gpclk, int *gpio, int wait, int srate, int nochan) {
 	// Catch only important signals
 	for (int i = 0; i < 25; i++) {
 		struct sigaction sa;
@@ -529,8 +535,17 @@ int tx(uint32_t carrier_freq, int divider, int prediv, char *audio_file, int rds
 	cbp--;
 	cbp->next = mem_virt_to_phys(mbox.virt_addr);
 
+	// Initialize the baseband generator
+	if (mpx_input_file) {
+		mpx_mode = 1;
+		if (mpx_input_open(mpx_input_file, srate, nochan) < 0) return 1;
+	} else {
+		if (fm_mpx_open(audio_file, 5000, cutoff, preemphasis_cutoff, srate, nochan) < 0) return 1;
+	}
+
 	// Here we define the rate at which we want to update the GPCLK control register
-	double srdivider = (((double)PLLD_CLOCK)/(1e3*2*228*(1.+ppm/1.e6)));
+	double sr_khz = mpx_input_file ? (mpx_input_samplerate / 1e3) : 228;
+	double srdivider = (((double)PLLD_CLOCK)/(1e3*2*sr_khz*(1.+ppm/1.e6)));
 	uint32_t idivider = (uint32_t)srdivider;
 	uint32_t fdivider = (uint32_t)((srdivider - idivider)*pow(2, 12));
 
@@ -569,36 +584,35 @@ int tx(uint32_t carrier_freq, int divider, int prediv, char *audio_file, int rds
 	int data_len = 0;
 	int data_index = 0;
 
-	// Initialize the baseband generator
-	if(fm_mpx_open(audio_file, 5000, cutoff, preemphasis_cutoff, srate, nochan) < 0) return 1;
+	if (!mpx_input_file) {
+		// Initialize the RDS modulator
+		set_rds_pi(pi);
+		set_rds_ps(ps);
+		set_rds_rt(rt);
+		set_rds_pty(pty);
+		set_rds_tp(tp);
+		set_rds_ms(1);
+		set_rds_ab(0);
 
-	// Initialize the RDS modulator
-	set_rds_pi(pi);
-	set_rds_ps(ps);
-	set_rds_rt(rt);
-	set_rds_pty(pty);
-	set_rds_tp(tp);
-	set_rds_ms(1);
-	set_rds_ab(0);
+		printf("RDS Options:\n");
 
-	printf("RDS Options:\n");
-
-	if(rds) {
-		printf("RDS: %i, ", rds);
-		printf("PI: %04X, PS: \"%s\", PTY: %i\n", pi, ps, pty);
-		printf("RT: \"%s\"\n", rt);
-		if(af_array[0]) {
-			set_rds_af(af_array);
-			printf("AF: ");
-			int f;
-			for(f = 1; f < af_array[0]+1; f++) {
-				printf("%f Mhz ", (float)(af_array[f]+875)/10);
+		if(rds) {
+			printf("RDS: %i, ", rds);
+			printf("PI: %04X, PS: \"%s\", PTY: %i\n", pi, ps, pty);
+			printf("RT: \"%s\"\n", rt);
+			if(af_array[0]) {
+				set_rds_af(af_array);
+				printf("AF: ");
+				int f;
+				for(f = 1; f < af_array[0]+1; f++) {
+					printf("%f Mhz ", (float)(af_array[f]+875)/10);
+				}
+				printf("\n");
 			}
-			printf("\n");
 		}
-	}
-	else {
-		printf("RDS: %i\n", rds);
+		else {
+			printf("RDS: %i\n", rds);
+		}
 	}
 
 	// Initialize the control pipe reader
@@ -632,7 +646,12 @@ int tx(uint32_t carrier_freq, int divider, int prediv, char *audio_file, int rds
 		while (free_slots >= SUBSIZE) {
 			// Get more baseband samples if necessary
 			if(data_len == 0) {
-				if((data_len = fm_mpx_get_samples(data, DATA_SIZE, mpx, rds, wait)) < 0 ) {
+				if (mpx_input_file) {
+					data_len = mpx_input_get_samples(data, DATA_SIZE, mpx / 2);
+				} else {
+					data_len = fm_mpx_get_samples(data, DATA_SIZE, mpx, rds, wait);
+				}
+				if(data_len < 0) {
 					return 0;
 				}
 				data_index = 0;
@@ -713,6 +732,7 @@ int main(int argc, char **argv) {
 	int opt;
 
 	char *audio_file = NULL;
+	char *mpx_input_file = NULL;
 	char *control_pipe = NULL;
 	uint32_t carrier_freq = 87600000;
     	int rds = 1;
@@ -762,6 +782,7 @@ int main(int argc, char **argv) {
 		{"wait",	required_argument, NULL, 'W'},
 		{"srate",	required_argument, NULL, 'S'},
 		{"nochan",	required_argument, NULL, 'N'},
+		{"mpxin",	required_argument, NULL, 'M'},
 
 		{"rds", 	required_argument, NULL, 'rds'},
 		{"pi", 		required_argument, NULL, 'pi'},
@@ -861,6 +882,10 @@ int main(int argc, char **argv) {
 				nochan = atoi(optarg);
 				break;
 
+			case 'M': //mpxin
+				mpx_input_file = optarg;
+				break;
+
 			case 'rds': //rds
 				rds = atoi(optarg);
 				break;
@@ -900,10 +925,15 @@ int main(int argc, char **argv) {
 				fatal("Help:\n"
 				      "Syntax: pi_fm_adv [--audio (-a) file] [--freq (-f) frequency] [--dev (-d) deviation] [--ppm (-p) ppm-error]\n"
 				      "                  [--cutoff (-c) cutoff-freq] [--preemph (-P) preemphasis] [--div (-D) divider] \n"
-				      "                  [--prediv (-r) prediv] [--mpx (-m) mpx-power] [--power (-w) output-power] [--gpio (-g) gpio-pin]\n" 
+				      "                  [--prediv (-r) prediv] [--mpx (-m) mpx-power] [--power (-w) output-power] [--gpio (-g) gpio-pin]\n"
 				      "                  [--gpclk (-G) gpclk {0, 1, 2}] [--pll (-l) PLL {a, c}] [--wait (-W) wait-switch]\n"
 				      "                  [--rds rds-switch] [--pi pi-code] [--ps ps-text] [--rt radiotext] [--tp traffic-program]\n"
-				      "                  [--pty program-type] [--af alternative-freq] [--ctl (-C) control-pipe]\n");
+				      "                  [--pty program-type] [--af alternative-freq] [--ctl (-C) control-pipe]\n"
+				      "                  [--mpxin (-M) mpx-input-file]\n"
+				      "\n"
+				      "  --mpxin (-M)    Pre-built composite MPX input file or - for stdin.\n"
+				      "                  Bypasses all internal audio processing, stereo encoding, and RDS.\n"
+				      "                  Use --srate and --nochan for raw stdin input.\n");
 
 				break;
 
@@ -918,6 +948,9 @@ int main(int argc, char **argv) {
 		}
 	}
 
+	if(audio_file && mpx_input_file)
+		fatal("Cannot use both --audio and --mpxin at the same time.\n");
+
 	if(gpio[0] == 0) gpio[++gpio[0]] = 4;
 
 	alternative_freq[0] = af_size;
@@ -926,8 +959,8 @@ int main(int argc, char **argv) {
 	if(divc == 0) divc = findDivider(carrier_freq*prediv, deviation, xtal_freq_recip);
 
 	printf("Carrier: %3.2f Mhz, VCO: %4.1f MHz, Multiplier: %f, Divider: %d\n", carrier_freq/1e6, (double)carrier_freq*prediv * divc / 1e6, carrier_freq*prediv * divc * xtal_freq_recip, divc);
-	
-	int errcode = tx(carrier_freq, divc, prediv, audio_file, rds, pi, ps, rt, alternative_freq, ppm, deviation, mpx, cutoff, preemphasis_cutoff, control_pipe, pty, tp, power, pll, gpclk, gpio, wait, srate, nochan);
+
+	int errcode = tx(carrier_freq, divc, prediv, audio_file, mpx_input_file, rds, pi, ps, rt, alternative_freq, ppm, deviation, mpx, cutoff, preemphasis_cutoff, control_pipe, pty, tp, power, pll, gpclk, gpio, wait, srate, nochan);
 
 	terminate(errcode);
 }


### PR DESCRIPTION
Allows feeding a pre-built composite MPX signal (e.g. from MicroMPX or Stereo Tool) directly to the DMA engine, bypassing internal audio processing, stereo encoding, and RDS generation.

- New module src/mpx_input.{c,h}: reads PCM via libsndfile, gain only
- DMA rate adapts to the input sample rate (e.g. 192 kHz) instead of the hardcoded 228 kHz used for internal RDS generation
- Input PCM is multiplied by mpx/2 so that full-scale (+/-1.0) maps to full deviation via the existing DMA loop scaling
- --audio and --mpxin are mutually exclusive

Usage:
  pi_fm_adv --mpxin composite.wav --freq 95.0 MicroMPX_Decoder | pi_fm_adv --mpxin - --freq 95.0 --srate 192000 --nochan 1